### PR TITLE
OCR-122 set minimal supported google cloud vision version

### DIFF
--- a/build/requirements.txt
+++ b/build/requirements.txt
@@ -1,7 +1,7 @@
 boto3
 deskew~=0.10.40
 google-cloud-storage
-google-cloud-vision
+google-cloud-vision>=3.0.0
 hyperscan==0.3.3 # due to https://github.com/darvid/python-hyperscan/issues/50
 jsonpickle
 loguru

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "boto3",
     "deskew~=0.10.40",
     "google-cloud-storage",
-    "google-cloud-vision",
+    "google-cloud-vision>=3.0.0",
     "hyperscan==0.3.3", # due to https://github.com/darvid/python-hyperscan/issues/50
     "jsonpickle",
     "loguru",


### PR DESCRIPTION
Leaving gcv dependencies without restriction to only supported version, may result in creating wrong python environment (using old gcv version).